### PR TITLE
Dependabot: ignore numpy>=2.5 and langchain-community>=0.4 (3.11 / langchain-core incompatible)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,16 @@ updates:
     groups:
       python-minor-patch:
         update-types: ["minor", "patch"]
+    ignore:
+      # numpy 2.5 dropped Python 3.11; the runtime image is python:3.11-slim.
+      # Remove this once the service moves to Python 3.12+.
+      - dependency-name: numpy
+        versions: [">=2.5.0"]
+      # langchain-community 0.4 requires langchain-core >=1.4 — a coordinated
+      # langchain 1.x ecosystem upgrade (core/community/openai/huggingface) that
+      # must be done by hand, not as a grouped minor/patch bump.
+      - dependency-name: langchain-community
+        versions: [">=0.4.0"]
 
   - package-ecosystem: github-actions
     directory: "/"


### PR DESCRIPTION
Follow-up from the rollout's Dependabot rescan. The grouped **python-minor-patch PR #15** fails its Docker build for two reasons that aren't safe minor/patch bumps:

1. **`numpy==2.5.0` requires Python ≥3.12**, but the runtime image is `python:3.11-slim` → `pip install` fails with *"No matching distribution found for numpy==2.5.0"*.
2. **`langchain-community==0.4.2` requires `langchain-core>=1.4.0`**, but `langchain-core` is pinned at `0.3.65` → `ResolutionImpossible`. Taking it needs a deliberate **langchain 1.x** upgrade across core/community/openai/huggingface.

This adds Dependabot `ignore` rules for both until the corresponding platform upgrades (Python 3.12 / langchain 1.x) are done on purpose. After this merges I'll **close #15**; Dependabot will re-propose a clean group (fastapi/uvicorn/pydantic/… ) that passes the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)