### PR TITLE
Dependabot: ignore actions-replace-env-variables >=0.1.5 (broken docker step)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,12 @@ updates:
     groups:
       github-actions:
         patterns: ["*"]
+    ignore:
+      # v0.1.5 of this org action regressed: its "Replace secrets in env file"
+      # step fails the docker job (the image build itself succeeds). Stay on
+      # v0.1.4 until it is fixed upstream.
+      - dependency-name: WSE-research/actions-replace-env-variables
+        versions: [">=0.1.5"]
 
   - package-ecosystem: docker
     directory: "/"


### PR DESCRIPTION
Follow-up to #24. v0.1.5 of `WSE-research/actions-replace-env-variables` regressed — its *Replace secrets in env file* step fails the docker job (the image build itself succeeds). #14 pins it back to v0.1.4; this ignore stops Dependabot re-proposing v0.1.5 until the action is fixed upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)