### PR TITLE
Dependabot: hold the langchain ecosystem (version-locked) so the rest of the group can flow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,11 +16,14 @@ updates:
       # Remove this once the service moves to Python 3.12+.
       - dependency-name: numpy
         versions: [">=2.5.0"]
-      # langchain-community 0.4 requires langchain-core >=1.4 — a coordinated
-      # langchain 1.x ecosystem upgrade (core/community/openai/huggingface) that
-      # must be done by hand, not as a grouped minor/patch bump.
+      # langchain-community is version-locked to langchain-core, which is pinned
+      # at 0.3.65; even a 0.3.x patch of community pulls langchain-core >0.3.65.
+      # Hold the whole langchain ecosystem for a deliberate, coordinated 1.x
+      # upgrade (core/community/openai/huggingface) rather than grouped bumps.
       - dependency-name: langchain-community
-        versions: [">=0.4.0"]
+      - dependency-name: langchain-core
+      - dependency-name: langchain-openai
+      - dependency-name: langchain-huggingface
 
   - package-ecosystem: github-actions
     directory: "/"


### PR DESCRIPTION
Continuation of the #15→#25 investigation. langchain-community is version-locked to langchain-core (pinned 0.3.65), so **any** community bump — even 0.3.31 — fails resolution. Verified via pip dry-run that holding langchain-community lets every other bump (fastapi 0.138, uvicorn 0.49, pydantic 2.13, numpy 2.4.6, pymongo 4.17, sentence-transformers 5.6, faiss-cpu 1.14, …) resolve on Python 3.11. This ignores the whole langchain family so the python-minor-patch group passes; the **langchain 1.x upgrade (#26 + community/openai/huggingface) should be done deliberately as one change**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)